### PR TITLE
Add support for SHTML

### DIFF
--- a/contrib/apps/httpserver_raw/makefsdata/makefsdata
+++ b/contrib/apps/httpserver_raw/makefsdata/makefsdata
@@ -23,6 +23,8 @@ while($file = <FILES>) {
     print(HEADER "Server: lwIP/pre-0.6 (http://www.sics.se/~adam/lwip/)\r\n");
     if($file =~ /\.html$/) {
 	print(HEADER "Content-type: text/html\r\n");
+    } elsif($file =~ /\.shtml$/) {
+	print(HEADER "Content-type: text/html shtml\r\n");
     } elsif($file =~ /\.gif$/) {
 	print(HEADER "Content-type: image/gif\r\n");
     } elsif($file =~ /\.png$/) {


### PR DESCRIPTION
SHMTL files got a wrong mimetype (`text/plain`). See also https://stackoverflow.com/questions/70468042/stm32-lwip-shtml-page-not-rendering-source-code-displayed-instead